### PR TITLE
Fix/fix date

### DIFF
--- a/src/infra/databases/drizzle/repositories/transaction.repository.ts
+++ b/src/infra/databases/drizzle/repositories/transaction.repository.ts
@@ -142,6 +142,7 @@ export class TransactionRepositoryImplementation implements TransactionRepositor
       .where(
         and(
           eq(schema.transactions.workspaceId, workspaceId),
+          eq(schema.transactions.status, 'COMPLETED'),
           gte(schema.transactions.date, startDate),
           lte(schema.transactions.date, endDate),
         ),

--- a/src/modules/account/features/delete-account/delete-account.handler.spec.ts
+++ b/src/modules/account/features/delete-account/delete-account.handler.spec.ts
@@ -1,4 +1,5 @@
 import { AccountType } from '@constants/enums';
+import { RedisService } from '@infra/cache/redis/RedisService';
 import { CheckingAccount } from '@modules/account/entities/CheckingAccount';
 import { AccountRepository } from '@modules/account/repositories/contracts/AccountRepository';
 import { UnauthorizedError } from '@shared/errors/UnauthorizedError';
@@ -25,6 +26,7 @@ function makeAccount(workspaceId = 'ws-1') {
 describe('DeleteAccountService', () => {
   let service: DeleteAccountService;
   let accountRepository: jest.Mocked<AccountRepository>;
+  let redisService: jest.Mocked<Pick<RedisService, 'delByPattern'>>;
 
   beforeEach(() => {
     accountRepository = {
@@ -38,7 +40,14 @@ describe('DeleteAccountService', () => {
       countByWorkspaceId: jest.fn(),
     } as jest.Mocked<AccountRepository>;
 
-    service = new DeleteAccountService(accountRepository);
+    redisService = {
+      delByPattern: jest.fn().mockResolvedValue(0),
+    };
+
+    service = new DeleteAccountService(
+      accountRepository,
+      redisService as unknown as RedisService,
+    );
   });
 
   afterEach(() => jest.clearAllMocks());
@@ -50,6 +59,7 @@ describe('DeleteAccountService', () => {
     expect(result.isLeft()).toBe(true);
     expect(result.value).toBeInstanceOf(UnauthorizedError);
     expect(accountRepository.delete).not.toHaveBeenCalled();
+    expect(redisService.delByPattern).not.toHaveBeenCalled();
   });
 
   it('should return left(UnauthorizedError) when account is not found', async () => {
@@ -58,6 +68,7 @@ describe('DeleteAccountService', () => {
     const result = await service.execute(makeRequest());
     expect(result.isLeft()).toBe(true);
     expect(result.value).toBeInstanceOf(UnauthorizedError);
+    expect(redisService.delByPattern).not.toHaveBeenCalled();
   });
 
   it('should delete the account and return right when authorized', async () => {
@@ -67,5 +78,14 @@ describe('DeleteAccountService', () => {
     const result = await service.execute(makeRequest());
     expect(result.isRight()).toBe(true);
     expect(accountRepository.delete).toHaveBeenCalledWith('acc-1');
+  });
+
+  it('should invalidate the report cache for the workspace after deleting', async () => {
+    accountRepository.findById.mockResolvedValue(makeAccount('ws-1'));
+    accountRepository.delete.mockResolvedValue();
+
+    await service.execute(makeRequest());
+
+    expect(redisService.delByPattern).toHaveBeenCalledWith('report:*:ws-1:*');
   });
 });

--- a/src/modules/account/features/delete-account/delete-account.handler.ts
+++ b/src/modules/account/features/delete-account/delete-account.handler.ts
@@ -1,4 +1,5 @@
 import { AccountRepository } from '@modules/account/repositories/contracts/AccountRepository';
+import { RedisService } from '@infra/cache/redis/RedisService';
 import { Injectable } from '@nestjs/common';
 import { TokenPayloadSchema } from '@providers/auth/strategys/jwtStrategy';
 import { Service } from '@shared/core/contracts/Service';
@@ -10,7 +11,10 @@ type Request = DeleteAccountRequest & Pick<TokenPayloadSchema, 'workspaceId'>;
 
 @Injectable()
 export class DeleteAccountService implements Service<Request, Error, void> {
-  constructor(private readonly accountRepository: AccountRepository) {}
+  constructor(
+    private readonly accountRepository: AccountRepository,
+    private readonly redisService: RedisService,
+  ) {}
 
   async execute({
     accountId,
@@ -23,6 +27,7 @@ export class DeleteAccountService implements Service<Request, Error, void> {
     }
 
     await this.accountRepository.delete(accountId);
+    await this.redisService.delByPattern(`report:*:${workspaceId}:*`);
 
     return right(undefined);
   }

--- a/src/providers/date/implementations/Dayjs.spec.ts
+++ b/src/providers/date/implementations/Dayjs.spec.ts
@@ -1,0 +1,122 @@
+import { DayJsDateProvider } from './Dayjs';
+
+describe('DayJsDateProvider', () => {
+  let provider: DayJsDateProvider;
+
+  beforeEach(() => {
+    provider = new DayJsDateProvider();
+  });
+
+  /**
+   * Regression tests for timezone-aware date parsing.
+   *
+   * Bug: When a date string "YYYY-MM-DD" was passed to methods like startOfDay,
+   * dayjs parsed it as UTC midnight, then converted to the local timezone,
+   * shifting the calendar date back by one day for UTC-3 (America/Sao_Paulo).
+   *
+   * Fix: Use dayjs.tz(date, tz) for string inputs so the string is interpreted
+   * directly in the target timezone.
+   */
+  describe('startOfDay', () => {
+    it('should return the start of the given day in the specified timezone (not the previous day)', () => {
+      const result = provider.startOfDay('2026-05-04', 'America/Sao_Paulo');
+
+      expect(result.getUTCFullYear()).toBe(2026);
+      expect(result.getUTCMonth()).toBe(4); // May = 4
+      expect(result.getUTCDate()).toBe(4);
+      // UTC-3 midnight = 03:00 UTC
+      expect(result.getUTCHours()).toBe(3);
+      expect(result.getUTCMinutes()).toBe(0);
+    });
+
+    it('should NOT shift the date back one day for UTC-3 timezones', () => {
+      const result = provider.startOfDay('2026-01-01', 'America/Sao_Paulo');
+
+      // Before the fix: dayjs("2026-01-01") → UTC midnight → converted to SP
+      // → 2025-12-31T21:00-03:00 → startOf('day') → 2025-12-31
+      expect(result.getUTCFullYear()).toBe(2026);
+      expect(result.getUTCMonth()).toBe(0); // January
+      expect(result.getUTCDate()).toBe(1);
+    });
+
+    it('should work correctly for Date object inputs', () => {
+      const input = new Date('2026-05-04T12:00:00Z');
+      const result = provider.startOfDay(input, 'America/Sao_Paulo');
+
+      // 2026-05-04T12:00Z is 2026-05-04T09:00-03:00 → startOf day = 2026-05-04T00:00-03:00 = 2026-05-04T03:00Z
+      expect(result.getUTCFullYear()).toBe(2026);
+      expect(result.getUTCMonth()).toBe(4);
+      expect(result.getUTCDate()).toBe(4);
+    });
+
+    it('should work for UTC timezone', () => {
+      const result = provider.startOfDay('2026-05-04', 'UTC');
+
+      expect(result.getUTCFullYear()).toBe(2026);
+      expect(result.getUTCMonth()).toBe(4);
+      expect(result.getUTCDate()).toBe(4);
+      expect(result.getUTCHours()).toBe(0);
+    });
+  });
+
+  describe('endOfDay', () => {
+    it('should return the end of the given day in the specified timezone (not the previous day)', () => {
+      const result = provider.endOfDay('2026-05-04', 'America/Sao_Paulo');
+
+      // End of 2026-05-04 in SP (-03:00) = 2026-05-04T23:59:59-03:00 = 2026-05-05T02:59:59Z
+      expect(result.getUTCFullYear()).toBe(2026);
+      expect(result.getUTCMonth()).toBe(4);
+      expect(result.getUTCDate()).toBe(5);
+      expect(result.getUTCHours()).toBe(2);
+      expect(result.getUTCMinutes()).toBe(59);
+    });
+
+    it('should NOT shift the date back one day for UTC-3 timezones', () => {
+      const result = provider.endOfDay('2026-01-01', 'America/Sao_Paulo');
+
+      // End of 2026-01-01 in SP (-03:00) = 2026-01-01T23:59:59.999-03:00 = 2026-01-02T02:59:59.999Z
+      // The important check: the local calendar date is Jan 1, not Dec 31
+      const localDate = new Date(
+        result.toLocaleString('en-US', { timeZone: 'America/Sao_Paulo' }),
+      );
+      expect(localDate.getFullYear()).toBe(2026);
+      expect(localDate.getMonth()).toBe(0);
+      expect(localDate.getDate()).toBe(1);
+    });
+  });
+
+  describe('startOfMonth', () => {
+    it('should return the first day of the given month in the specified timezone', () => {
+      const result = provider.startOfMonth('2026-05-15', 'America/Sao_Paulo');
+
+      // First of May in SP (-03:00) = 2026-05-01T00:00:00-03:00 = 2026-05-01T03:00:00Z
+      expect(result.getUTCFullYear()).toBe(2026);
+      expect(result.getUTCMonth()).toBe(4);
+      expect(result.getUTCDate()).toBe(1);
+      expect(result.getUTCHours()).toBe(3);
+    });
+
+    it('should NOT return the last day of the previous month for UTC-3 timezones', () => {
+      const result = provider.startOfMonth('2026-01-15', 'America/Sao_Paulo');
+
+      // Before the fix: "2026-01-15" → UTC midnight → Dec 31 in SP → startOfMonth = Dec 1
+      // After the fix: interpreted as Jan 15 in SP → startOfMonth = Jan 1 in SP
+      expect(result.getUTCFullYear()).toBe(2026);
+      expect(result.getUTCMonth()).toBe(0); // January, not December
+    });
+  });
+
+  describe('endOfMonth', () => {
+    it('should return the last day of the given month in the specified timezone', () => {
+      const result = provider.endOfMonth('2026-05-15', 'America/Sao_Paulo');
+
+      // Last of May in SP = 2026-05-31T23:59:59-03:00 = 2026-06-01T02:59:59Z
+      const localDate = new Date(
+        result.toLocaleString('en-US', { timeZone: 'America/Sao_Paulo' }),
+      );
+      expect(localDate.getFullYear()).toBe(2026);
+      expect(localDate.getMonth()).toBe(4); // May
+      expect(localDate.getDate()).toBe(31);
+    });
+  });
+});

--- a/src/providers/date/implementations/Dayjs.ts
+++ b/src/providers/date/implementations/Dayjs.ts
@@ -39,18 +39,30 @@ export class DayJsDateProvider implements DateProvider {
   }
 
   startOfDay(date: string | Date, tz: string = 'America/Sao_Paulo'): Date {
+    if (typeof date === 'string') {
+      return dayjs.tz(date, tz).startOf('day').toDate();
+    }
     return dayjs(date).tz(tz).startOf('day').toDate();
   }
 
   startOfMonth(date: string | Date, tz: string = 'America/Sao_Paulo'): Date {
+    if (typeof date === 'string') {
+      return dayjs.tz(date, tz).startOf('month').toDate();
+    }
     return dayjs(date).tz(tz).startOf('month').toDate();
   }
 
   endOfMonth(date: string | Date, tz: string = 'America/Sao_Paulo'): Date {
+    if (typeof date === 'string') {
+      return dayjs.tz(date, tz).endOf('month').toDate();
+    }
     return dayjs(date).tz(tz).endOf('month').toDate();
   }
 
   endOfDay(date: string | Date, tz: string = 'America/Sao_Paulo'): Date {
+    if (typeof date === 'string') {
+      return dayjs.tz(date, tz).endOf('day').toDate();
+    }
     return dayjs(date).tz(tz).endOf('day').toDate();
   }
 


### PR DESCRIPTION
This pull request introduces two main improvements: it fixes timezone-related bugs in date calculations by updating the `DayJsDateProvider`, and it enhances the account deletion feature by ensuring related cache entries are invalidated. Additionally, it adds comprehensive regression tests for the date provider to prevent future timezone issues.

**Timezone handling improvements:**

* Fixed a critical bug in `DayJsDateProvider` where date string inputs (like `"YYYY-MM-DD"`) were incorrectly interpreted as UTC, causing off-by-one-day errors in timezones such as `America/Sao_Paulo`. Now, string dates are parsed directly in the specified timezone using `dayjs.tz(date, tz)`. This fix applies to the `startOfDay`, `endOfDay`, `startOfMonth`, and `endOfMonth` methods.
* Added a comprehensive regression test suite for `DayJsDateProvider` to verify correct behavior for timezone-aware date parsing, preventing regressions on this issue.

**Account deletion and cache invalidation:**

* Updated `DeleteAccountService` to accept a `RedisService` instance and, after deleting an account, invalidate all report cache entries for the workspace using `delByPattern('report:*:${workspaceId}:*')`. [[1]](diffhunk://#diff-e380e2f3a769eb071b036ecc509ecf95828cdbe5b66d44787cde25abbc92c5aaR2) [[2]](diffhunk://#diff-e380e2f3a769eb071b036ecc509ecf95828cdbe5b66d44787cde25abbc92c5aaL13-R17) [[3]](diffhunk://#diff-e380e2f3a769eb071b036ecc509ecf95828cdbe5b66d44787cde25abbc92c5aaR30)
* Enhanced the corresponding test suite to mock `RedisService` and verify that cache invalidation is called appropriately during account deletion, and not called when deletion is unauthorized or the account is not found. [[1]](diffhunk://#diff-968374213a85df0270493c1622950f3b91c86dfed598624a6030c30aeb005661R2) [[2]](diffhunk://#diff-968374213a85df0270493c1622950f3b91c86dfed598624a6030c30aeb005661R29) [[3]](diffhunk://#diff-968374213a85df0270493c1622950f3b91c86dfed598624a6030c30aeb005661L41-R50) [[4]](diffhunk://#diff-968374213a85df0270493c1622950f3b91c86dfed598624a6030c30aeb005661R62) [[5]](diffhunk://#diff-968374213a85df0270493c1622950f3b91c86dfed598624a6030c30aeb005661R71) [[6]](diffhunk://#diff-968374213a85df0270493c1622950f3b91c86dfed598624a6030c30aeb005661R82-R90)

**Transaction filtering:**

* Modified the transaction repository query to filter only transactions with status `'COMPLETED'` when fetching by workspace and date range, improving data accuracy for downstream consumers.This pull request fixes timezone handling bugs in the `DayJsDateProvider` so that date calculations are correct for string inputs, especially in non-UTC timezones like `America/Sao_Paulo`. It also adds comprehensive regression tests to ensure the fixes work as expected and prevent future regressions.

**Bug Fixes for Timezone Handling:**

* Updated the `startOfDay`, `endOfDay`, `startOfMonth`, and `endOfMonth` methods in `DayJsDateProvider` to use `dayjs.tz(date, tz)` when the input is a string, ensuring the date is interpreted directly in the specified timezone and preventing off-by-one-day errors in timezones west of UTC (e.g., UTC-3).

**Testing Improvements:**

* Added a new test suite `Dayjs.spec.ts` with regression tests covering all edge cases for timezone-aware date parsing, ensuring that the start and end of days and months are calculated correctly for both string and `Date` inputs and for various timezones.