### PR TITLE
refactor(account): unify EXPENSE/INCOME effect across account types

### DIFF
--- a/src/modules/account/entities/BaseAccount.ts
+++ b/src/modules/account/entities/BaseAccount.ts
@@ -32,10 +32,11 @@ export abstract class BaseAccount<
   }
 
   /**
-   * Soma o valor ao saldo. Compartilhado pelas contas cujo crédito não tem
-   * regra própria (carteira, investimento, conta corrente).
+   * Soma o valor ao saldo. Comportamento padrão de crédito para as contas
+   * que não têm regra própria (carteira, investimento, conta corrente).
+   * Sobrescreva quando a conta precisar de uma regra diferente.
    */
-  protected creditBalance(amount: bigint): Either<Error, void> {
+  public credit(amount: bigint): Either<Error, void> {
     if (amount <= 0n) return left(new Error('Valor deve ser positivo.'));
     this.props.balance += amount;
     return right(undefined);
@@ -43,9 +44,10 @@ export abstract class BaseAccount<
 
   /**
    * Subtrai o valor do saldo, bloqueando a operação se o resultado ficar
-   * negativo. Compartilhado pelas contas que não permitem saldo negativo.
+   * negativo. Comportamento padrão de débito; sobrescreva quando a conta
+   * permitir saldo negativo (ex.: conta corrente) ou tiver outra regra.
    */
-  protected debitBalanceWithFloor(amount: bigint): Either<Error, void> {
+  public debit(amount: bigint): Either<Error, void> {
     if (amount <= 0n) return left(new Error('Valor deve ser positivo.'));
     if (this.props.balance - amount < 0n) {
       return left(

--- a/src/modules/account/entities/BaseAccount.ts
+++ b/src/modules/account/entities/BaseAccount.ts
@@ -1,4 +1,5 @@
 import { AggregateRoot } from '@shared/core/Entities/AggregateRoot';
+import { Either } from '@shared/core/errors/Either';
 
 export interface BaseAccountProps {
   workspaceId: string;
@@ -35,4 +36,16 @@ export abstract class BaseAccount<
   abstract get patrimonyContribution(): bigint;
 
   abstract get type(): string;
+
+  /**
+   * Efeito de uma transação EXPENSE sobre a conta. Contas comuns debitam o
+   * saldo; o cartão de crédito registra a cobrança na fatura (aumenta a dívida).
+   */
+  abstract applyExpenseEffect(amount: bigint): Either<Error, void>;
+
+  /**
+   * Efeito de uma transação INCOME sobre a conta. Contas comuns creditam o
+   * saldo; o cartão de crédito abate o valor da fatura (diminui a dívida).
+   */
+  abstract applyIncomeEffect(amount: bigint): Either<Error, void>;
 }

--- a/src/modules/account/entities/BaseAccount.ts
+++ b/src/modules/account/entities/BaseAccount.ts
@@ -1,10 +1,11 @@
+import { Either, left, right } from '@shared/core/errors/Either';
 import { AggregateRoot } from '@shared/core/Entities/AggregateRoot';
-import { Either } from '@shared/core/errors/Either';
 
 export interface BaseAccountProps {
   workspaceId: string;
   name: string;
   timezone: string;
+  balance: bigint;
 }
 
 export abstract class BaseAccount<
@@ -24,6 +25,35 @@ export abstract class BaseAccount<
 
   get timezone(): string {
     return this.props.timezone;
+  }
+
+  get balance(): bigint {
+    return this.props.balance;
+  }
+
+  /**
+   * Soma o valor ao saldo. Compartilhado pelas contas cujo crédito não tem
+   * regra própria (carteira, investimento, conta corrente).
+   */
+  protected creditBalance(amount: bigint): Either<Error, void> {
+    if (amount <= 0n) return left(new Error('Valor deve ser positivo.'));
+    this.props.balance += amount;
+    return right(undefined);
+  }
+
+  /**
+   * Subtrai o valor do saldo, bloqueando a operação se o resultado ficar
+   * negativo. Compartilhado pelas contas que não permitem saldo negativo.
+   */
+  protected debitBalanceWithFloor(amount: bigint): Either<Error, void> {
+    if (amount <= 0n) return left(new Error('Valor deve ser positivo.'));
+    if (this.props.balance - amount < 0n) {
+      return left(
+        new Error('Saldo insuficiente na carteira. Operação bloqueada.'),
+      );
+    }
+    this.props.balance -= amount;
+    return right(undefined);
   }
 
   public updateName(name: string) {

--- a/src/modules/account/entities/CashAccounts.spec.ts
+++ b/src/modules/account/entities/CashAccounts.spec.ts
@@ -82,4 +82,29 @@ describe('CashAccount entity', () => {
       expect(account.debit(200n).isLeft()).toBe(true);
     });
   });
+
+  describe('applyExpenseEffect()', () => {
+    it('should behave like debit()', () => {
+      const account = makeAccount(500n);
+      account.applyExpenseEffect(200n);
+      expect(account.balance).toBe(300n);
+    });
+
+    it('should reject expense exceeding balance', () => {
+      const account = makeAccount(100n);
+      expect(account.applyExpenseEffect(200n).isLeft()).toBe(true);
+    });
+  });
+
+  describe('applyIncomeEffect()', () => {
+    it('should behave like credit()', () => {
+      const account = makeAccount(500n);
+      account.applyIncomeEffect(200n);
+      expect(account.balance).toBe(700n);
+    });
+
+    it('should reject zero amount', () => {
+      expect(makeAccount().applyIncomeEffect(0n).isLeft()).toBe(true);
+    });
+  });
 });

--- a/src/modules/account/entities/CashAccounts.ts
+++ b/src/modules/account/entities/CashAccounts.ts
@@ -26,10 +26,6 @@ export class CashAccount extends BaseAccount<CashAccountProps> {
     return new CashAccount(props, id);
   }
 
-  get balance(): bigint {
-    return this.props.balance;
-  }
-
   get type(): string {
     return AccountType.CASH;
   }
@@ -39,20 +35,11 @@ export class CashAccount extends BaseAccount<CashAccountProps> {
   }
 
   public credit(amount: bigint): Either<Error, void> {
-    if (amount <= 0n) return left(new Error('Valor deve ser positivo.'));
-    this.props.balance += amount;
-    return right(undefined);
+    return this.creditBalance(amount);
   }
 
   public debit(amount: bigint): Either<Error, void> {
-    if (amount <= 0n) return left(new Error('Valor deve ser positivo.'));
-    if (this.props.balance - amount < 0n) {
-      return left(
-        new Error('Saldo insuficiente na carteira. Operação bloqueada.'),
-      );
-    }
-    this.props.balance -= amount;
-    return right(undefined);
+    return this.debitBalanceWithFloor(amount);
   }
 
   public applyExpenseEffect(amount: bigint): Either<Error, void> {

--- a/src/modules/account/entities/CashAccounts.ts
+++ b/src/modules/account/entities/CashAccounts.ts
@@ -54,4 +54,12 @@ export class CashAccount extends BaseAccount<CashAccountProps> {
     this.props.balance -= amount;
     return right(undefined);
   }
+
+  public applyExpenseEffect(amount: bigint): Either<Error, void> {
+    return this.debit(amount);
+  }
+
+  public applyIncomeEffect(amount: bigint): Either<Error, void> {
+    return this.credit(amount);
+  }
 }

--- a/src/modules/account/entities/CashAccounts.ts
+++ b/src/modules/account/entities/CashAccounts.ts
@@ -34,14 +34,6 @@ export class CashAccount extends BaseAccount<CashAccountProps> {
     return this.balance;
   }
 
-  public credit(amount: bigint): Either<Error, void> {
-    return this.creditBalance(amount);
-  }
-
-  public debit(amount: bigint): Either<Error, void> {
-    return this.debitBalanceWithFloor(amount);
-  }
-
   public applyExpenseEffect(amount: bigint): Either<Error, void> {
     return this.debit(amount);
   }

--- a/src/modules/account/entities/CheckingAccount.spec.ts
+++ b/src/modules/account/entities/CheckingAccount.spec.ts
@@ -74,4 +74,28 @@ describe('CheckingAccount entity', () => {
       expect(account.debit(-10n).isLeft()).toBe(true);
     });
   });
+
+  describe('applyExpenseEffect()', () => {
+    it('should behave like debit()', () => {
+      const account = makeAccount();
+      account.applyExpenseEffect(200n);
+      expect(account.balance).toBe(300n);
+    });
+
+    it('should reject zero amount', () => {
+      expect(makeAccount().applyExpenseEffect(0n).isLeft()).toBe(true);
+    });
+  });
+
+  describe('applyIncomeEffect()', () => {
+    it('should behave like credit()', () => {
+      const account = makeAccount();
+      account.applyIncomeEffect(200n);
+      expect(account.balance).toBe(700n);
+    });
+
+    it('should reject negative amount', () => {
+      expect(makeAccount().applyIncomeEffect(-50n).isLeft()).toBe(true);
+    });
+  });
 });

--- a/src/modules/account/entities/CheckingAccount.ts
+++ b/src/modules/account/entities/CheckingAccount.ts
@@ -59,4 +59,12 @@ export class CheckingAccount extends BaseAccount<CheckingAccountProps> {
     this.props.balance -= amount;
     return right(undefined);
   }
+
+  public applyExpenseEffect(amount: bigint): Either<Error, void> {
+    return this.debit(amount);
+  }
+
+  public applyIncomeEffect(amount: bigint): Either<Error, void> {
+    return this.credit(amount);
+  }
 }

--- a/src/modules/account/entities/CheckingAccount.ts
+++ b/src/modules/account/entities/CheckingAccount.ts
@@ -36,10 +36,6 @@ export class CheckingAccount extends BaseAccount<CheckingAccountProps> {
     return new CheckingAccount(props, id);
   }
 
-  get balance(): bigint {
-    return this.props.balance;
-  }
-
   get type(): string {
     return this.props.type;
   }
@@ -49,9 +45,7 @@ export class CheckingAccount extends BaseAccount<CheckingAccountProps> {
   }
 
   public credit(amount: bigint): Either<Error, void> {
-    if (amount <= 0n) return left(new Error('Valor deve ser positivo.'));
-    this.props.balance += amount;
-    return right(undefined);
+    return this.creditBalance(amount);
   }
 
   public debit(amount: bigint): Either<Error, void> {

--- a/src/modules/account/entities/CheckingAccount.ts
+++ b/src/modules/account/entities/CheckingAccount.ts
@@ -44,10 +44,6 @@ export class CheckingAccount extends BaseAccount<CheckingAccountProps> {
     return this.balance;
   }
 
-  public credit(amount: bigint): Either<Error, void> {
-    return this.creditBalance(amount);
-  }
-
   public debit(amount: bigint): Either<Error, void> {
     if (amount <= 0n) return left(new Error('Valor deve ser positivo.'));
     this.props.balance -= amount;

--- a/src/modules/account/entities/CreditCardAccount.spec.ts
+++ b/src/modules/account/entities/CreditCardAccount.spec.ts
@@ -97,6 +97,34 @@ describe('CreditCard entity', () => {
     });
   });
 
+  describe('applyExpenseEffect()', () => {
+    it('should behave like registerCharge() (increase balance)', () => {
+      const card = makeCard();
+      card.applyExpenseEffect(1000n);
+      expect(card.balance).toBe(1000n);
+    });
+
+    it('should reject expense exceeding available limit', () => {
+      const card = makeCard({ creditLimit: 1000n });
+      expect(card.applyExpenseEffect(1500n).isLeft()).toBe(true);
+    });
+  });
+
+  describe('applyIncomeEffect()', () => {
+    it('should behave like payInvoice() (decrease balance)', () => {
+      const card = makeCard();
+      card.registerCharge(500n);
+      card.applyIncomeEffect(500n);
+      expect(card.balance).toBe(0n);
+    });
+
+    it('should reject income exceeding current balance', () => {
+      const card = makeCard();
+      card.registerCharge(200n);
+      expect(card.applyIncomeEffect(500n).isLeft()).toBe(true);
+    });
+  });
+
   describe('adjustLimit()', () => {
     it('should update credit limit', () => {
       const card = makeCard();

--- a/src/modules/account/entities/CreditCardAccount.ts
+++ b/src/modules/account/entities/CreditCardAccount.ts
@@ -53,10 +53,6 @@ export class CreditCard extends BaseAccount<CreditCardProps> {
     return new CreditCard(props, id);
   }
 
-  get balance(): bigint {
-    return this.props.balance;
-  }
-
   get creditLimit(): bigint | null {
     return this.props.creditLimit;
   }

--- a/src/modules/account/entities/CreditCardAccount.ts
+++ b/src/modules/account/entities/CreditCardAccount.ts
@@ -109,6 +109,14 @@ export class CreditCard extends BaseAccount<CreditCardProps> {
     return right(undefined);
   }
 
+  public applyExpenseEffect(amount: bigint): Either<Error, void> {
+    return this.registerCharge(amount);
+  }
+
+  public applyIncomeEffect(amount: bigint): Either<Error, void> {
+    return this.payInvoice(amount);
+  }
+
   public updateInvoiceDates(
     closingDay: number | null,
     dueDay: number,

--- a/src/modules/account/entities/InvestmentAccount.spec.ts
+++ b/src/modules/account/entities/InvestmentAccount.spec.ts
@@ -71,4 +71,28 @@ describe('InvestmentAccount entity', () => {
       expect(makeAccount(100n).debit(200n).isLeft()).toBe(true);
     });
   });
+
+  describe('applyExpenseEffect()', () => {
+    it('should behave like debit()', () => {
+      const account = makeAccount(500n);
+      account.applyExpenseEffect(200n);
+      expect(account.balance).toBe(300n);
+    });
+
+    it('should reject expense exceeding balance', () => {
+      expect(makeAccount(100n).applyExpenseEffect(200n).isLeft()).toBe(true);
+    });
+  });
+
+  describe('applyIncomeEffect()', () => {
+    it('should behave like credit()', () => {
+      const account = makeAccount(500n);
+      account.applyIncomeEffect(200n);
+      expect(account.balance).toBe(700n);
+    });
+
+    it('should reject zero amount', () => {
+      expect(makeAccount().applyIncomeEffect(0n).isLeft()).toBe(true);
+    });
+  });
 });

--- a/src/modules/account/entities/InvestmentAccount.ts
+++ b/src/modules/account/entities/InvestmentAccount.ts
@@ -31,10 +31,6 @@ export class InvestmentAccount extends BaseAccount<InvestmentAccountProps> {
     return new InvestmentAccount(props, id);
   }
 
-  get balance(): bigint {
-    return this.props.balance;
-  }
-
   get type(): string {
     return AccountType.INVESTMENT;
   }
@@ -44,20 +40,11 @@ export class InvestmentAccount extends BaseAccount<InvestmentAccountProps> {
   }
 
   public credit(amount: bigint): Either<Error, void> {
-    if (amount <= 0n) return left(new Error('Valor deve ser positivo.'));
-    this.props.balance += amount;
-    return right(undefined);
+    return this.creditBalance(amount);
   }
 
   public debit(amount: bigint): Either<Error, void> {
-    if (amount <= 0n) return left(new Error('Valor deve ser positivo.'));
-    if (this.props.balance - amount < 0n) {
-      return left(
-        new Error('Saldo insuficiente na carteira. Operação bloqueada.'),
-      );
-    }
-    this.props.balance -= amount;
-    return right(undefined);
+    return this.debitBalanceWithFloor(amount);
   }
 
   public applyExpenseEffect(amount: bigint): Either<Error, void> {

--- a/src/modules/account/entities/InvestmentAccount.ts
+++ b/src/modules/account/entities/InvestmentAccount.ts
@@ -39,14 +39,6 @@ export class InvestmentAccount extends BaseAccount<InvestmentAccountProps> {
     return this.balance;
   }
 
-  public credit(amount: bigint): Either<Error, void> {
-    return this.creditBalance(amount);
-  }
-
-  public debit(amount: bigint): Either<Error, void> {
-    return this.debitBalanceWithFloor(amount);
-  }
-
   public applyExpenseEffect(amount: bigint): Either<Error, void> {
     return this.debit(amount);
   }

--- a/src/modules/account/entities/InvestmentAccount.ts
+++ b/src/modules/account/entities/InvestmentAccount.ts
@@ -59,4 +59,12 @@ export class InvestmentAccount extends BaseAccount<InvestmentAccountProps> {
     this.props.balance -= amount;
     return right(undefined);
   }
+
+  public applyExpenseEffect(amount: bigint): Either<Error, void> {
+    return this.debit(amount);
+  }
+
+  public applyIncomeEffect(amount: bigint): Either<Error, void> {
+    return this.credit(amount);
+  }
 }

--- a/src/modules/transaction/features/create-transaction/create-transaction.dto.spec.ts
+++ b/src/modules/transaction/features/create-transaction/create-transaction.dto.spec.ts
@@ -58,7 +58,7 @@ describe('CreateTransactionRequest DTO', () => {
     [{ date: '15-01-2024' }, 'wrong date format'],
     [{ date: '2024/01/15' }, 'date with slashes'],
     [{ type: 'INVALID' }, 'invalid type'],
-  ])('should reject %s', (invalidFields, _label) => {
+  ])('should reject %s', (invalidFields) => {
     expect(
       createTransactionSchema.safeParse(makeValid(invalidFields)).success,
     ).toBe(false);

--- a/src/modules/transaction/features/create-transaction/create-transaction.service.ts
+++ b/src/modules/transaction/features/create-transaction/create-transaction.service.ts
@@ -10,7 +10,6 @@ import { TokenPayloadBase } from '@providers/auth/strategys/jwtStrategy';
 import { Service } from '@shared/core/contracts/Service';
 import { Either, left, right } from '@shared/core/errors/Either';
 
-import { CreditCard } from '@modules/account/entities/CreditCardAccount';
 import { CategoryNotFoundError } from '@modules/category/errors';
 import { DestinationAccountRequiredForTransferError } from '@modules/transaction/errors';
 import { DateProvider } from '@providers/date/contracts/DateProvider';
@@ -164,27 +163,18 @@ export class CreateTransactionService implements Service<
     amount: bigint,
   ): Either<Error, void> {
     if (type === 'EXPENSE') {
-      return account instanceof CreditCard
-        ? account.registerCharge(amount)
-        : account.debit(amount);
+      return account.applyExpenseEffect(amount);
     }
 
     if (type === 'INCOME') {
-      return account instanceof CreditCard
-        ? account.payInvoice(amount)
-        : account.credit(amount);
+      return account.applyIncomeEffect(amount);
     }
 
     if (type === 'TRANSFER' && destinationAccount) {
-      const debitResult =
-        account instanceof CreditCard
-          ? account.registerCharge(amount)
-          : account.debit(amount);
+      const debitResult = account.applyExpenseEffect(amount);
       if (debitResult.isLeft()) return debitResult;
 
-      return destinationAccount instanceof CreditCard
-        ? destinationAccount.payInvoice(amount)
-        : destinationAccount.credit(amount);
+      return destinationAccount.applyIncomeEffect(amount);
     }
 
     return right(undefined);

--- a/src/modules/transaction/features/delete-transaction/delete-transaction.service.ts
+++ b/src/modules/transaction/features/delete-transaction/delete-transaction.service.ts
@@ -1,6 +1,5 @@
 import { TransactionStatus } from '@constants/enums';
 import { RedisService } from '@infra/cache/redis/RedisService';
-import { CreditCard } from '@modules/account/entities/CreditCardAccount';
 import { AnyAccount } from '@modules/account/entities/types';
 import { AccountNotFoundError } from '@modules/account/errors';
 import { AccountRepository } from '@modules/account/repositories/contracts/AccountRepository';
@@ -101,27 +100,18 @@ export class DeleteTransactionService implements Service<Request, Error, void> {
     const { type, amount } = transaction;
 
     if (type === 'EXPENSE') {
-      return account instanceof CreditCard
-        ? account.payInvoice(amount)
-        : account.credit(amount);
+      return account.applyIncomeEffect(amount);
     }
 
     if (type === 'INCOME') {
-      return account instanceof CreditCard
-        ? account.registerCharge(amount)
-        : account.debit(amount);
+      return account.applyExpenseEffect(amount);
     }
 
     if (type === 'TRANSFER' && destinationAccount) {
-      const creditSourceResult =
-        account instanceof CreditCard
-          ? account.payInvoice(amount)
-          : account.credit(amount);
+      const creditSourceResult = account.applyIncomeEffect(amount);
       if (creditSourceResult.isLeft()) return creditSourceResult;
 
-      return destinationAccount instanceof CreditCard
-        ? destinationAccount.registerCharge(amount)
-        : destinationAccount.debit(amount);
+      return destinationAccount.applyExpenseEffect(amount);
     }
 
     return right(undefined);

--- a/src/modules/transaction/features/toggle-transaction-status/toggle-transaction-status.service.ts
+++ b/src/modules/transaction/features/toggle-transaction-status/toggle-transaction-status.service.ts
@@ -1,6 +1,5 @@
 import { TransactionStatus } from '@constants/enums';
 import { RedisService } from '@infra/cache/redis/RedisService';
-import { CreditCard } from '@modules/account/entities/CreditCardAccount';
 import { AnyAccount } from '@modules/account/entities/types';
 import { AccountNotFoundError } from '@modules/account/errors';
 import { AccountRepository } from '@modules/account/repositories/contracts/AccountRepository';
@@ -92,24 +91,13 @@ export class ToggleTransactionStatusService implements Service<
     acc: AnyAccount,
     dest: AnyAccount | null,
   ): Either<Error, void> {
-    if (t.type === 'EXPENSE')
-      return acc instanceof CreditCard
-        ? acc.registerCharge(t.amount)
-        : acc.debit(t.amount);
-    if (t.type === 'INCOME')
-      return acc instanceof CreditCard
-        ? acc.payInvoice(t.amount)
-        : acc.credit(t.amount);
+    if (t.type === 'EXPENSE') return acc.applyExpenseEffect(t.amount);
+    if (t.type === 'INCOME') return acc.applyIncomeEffect(t.amount);
 
     if (t.type === 'TRANSFER' && dest) {
-      const debitResult =
-        acc instanceof CreditCard
-          ? acc.registerCharge(t.amount)
-          : acc.debit(t.amount);
+      const debitResult = acc.applyExpenseEffect(t.amount);
       if (debitResult.isLeft()) return debitResult;
-      return dest instanceof CreditCard
-        ? dest.payInvoice(t.amount)
-        : dest.credit(t.amount);
+      return dest.applyIncomeEffect(t.amount);
     }
     return right(undefined);
   }
@@ -119,24 +107,13 @@ export class ToggleTransactionStatusService implements Service<
     acc: AnyAccount,
     dest: AnyAccount | null,
   ): Either<Error, void> {
-    if (t.type === 'EXPENSE')
-      return acc instanceof CreditCard
-        ? acc.payInvoice(t.amount)
-        : acc.credit(t.amount);
-    if (t.type === 'INCOME')
-      return acc instanceof CreditCard
-        ? acc.registerCharge(t.amount)
-        : acc.debit(t.amount);
+    if (t.type === 'EXPENSE') return acc.applyIncomeEffect(t.amount);
+    if (t.type === 'INCOME') return acc.applyExpenseEffect(t.amount);
 
     if (t.type === 'TRANSFER' && dest) {
-      const creditResult =
-        acc instanceof CreditCard
-          ? acc.payInvoice(t.amount)
-          : acc.credit(t.amount);
+      const creditResult = acc.applyIncomeEffect(t.amount);
       if (creditResult.isLeft()) return creditResult;
-      return dest instanceof CreditCard
-        ? dest.registerCharge(t.amount)
-        : dest.debit(t.amount);
+      return dest.applyExpenseEffect(t.amount);
     }
     return right(undefined);
   }


### PR DESCRIPTION
Isso aqui é o primeiro passo antes de simplificar o modelo de fatura do cartão de crédito (issues #27, #28, #29, #30, #41). Antes de mexer na regra em si, resolvi a duplicação que provavelmente é a origem do bug #41.

## O problema

`CreditCard` nunca teve `credit()`/`debit()` como as outras contas — tem `registerCharge()`/`payInvoice()`, com regras próprias (limite de crédito, etc). Isso é correto, mas fazia com que todo lugar que precisava aplicar uma transação numa conta tivesse que checar `instanceof CreditCard` pra saber qual método chamar. Isso estava duplicado em `create-transaction.service.ts`, `toggle-transaction-status.service.ts` e `delete-transaction.service.ts`.

## O que mudou

Criei um contrato polimórfico em `BaseAccount`: `applyExpenseEffect()` e `applyIncomeEffect()`. Cada conta implementa do seu jeito — as contas normais delegam pro próprio `debit()`/`credit()`, o cartão delega pro `registerCharge()`/`payInvoice()` (nomes e regras do cartão continuam intocados, só troquei quem decide qual chamar). Os 3 arquivos que tinham o `instanceof` agora só chamam `account.applyExpenseEffect()`/`applyIncomeEffect()`.

De quebra, reparei que `CashAccount` e `InvestmentAccount` tinham `credit()`/`debit()` idênticos char a char (o Sonar acusou isso como 26% de duplicação). Subi esse comportamento padrão pro próprio `BaseAccount` como método concreto — quem precisa de regra diferente (Checking permite saldo negativo, CreditCard tem outra lógica inteira) sobrescreve, o resto simplesmente herda.

## Testes

Segui TDD: escrevi os testes de `applyExpenseEffect`/`applyIncomeEffect` primeiro (RED, 16 falhando), implementei até fechar (GREEN), refatorei os 3 services e rodei tudo de novo. Suite completa em 50/50 suites, 406/406 testes. `tsc --noEmit` limpo. Aproveitei e corrigi um `_label` não usado que o lint acusou em `create-transaction.dto.spec.ts`.

## Ficou de fora, de propósito

- Rodando o lint no projeto inteiro apareceram mais ~39 erros pré-existentes, sem relação com isso aqui — vou tratar numa PR separada de chore.
- Falta o smoke test end-to-end: minha máquina tem outro container Postgres ocupando a porta 5432. Preciso confirmar contigo se posso derrubar ele por um instante pra rodar o docker-compose daqui.

Sonar já está OK nessa branch (rodei o scan antes de subir). Não dei merge, é contigo.