### PR TITLE
Support total-amount mode for recurring transactions (parcelamento)

### DIFF
--- a/src/modules/transaction/features/create-recurring-transaction/create-recurring-transaction.dto.spec.ts
+++ b/src/modules/transaction/features/create-recurring-transaction/create-recurring-transaction.dto.spec.ts
@@ -1,5 +1,4 @@
 import { RecurrenceFrequency, TransactionType } from '@constants/enums';
-import { ZodValidationPipe } from '@shared/pipes/ZodValidation';
 import { z } from 'zod';
 
 const createRecurringTransactionSchema = z
@@ -81,9 +80,52 @@ const createRecurringTransactionSchema = z
     },
   );
 
-export type CreateRecurringTransactionRequest = z.infer<
-  typeof createRecurringTransactionSchema
->;
-export const CreateRecurringTransactionPipe = new ZodValidationPipe(
-  createRecurringTransactionSchema,
-);
+describe('CreateRecurringTransactionRequest DTO', () => {
+  function makeValid(overrides: Record<string, unknown> = {}) {
+    return {
+      accountId: '123e4567-e89b-12d3-a456-426614174000',
+      title: 'Aluguel',
+      amount: 150000,
+      frequency: RecurrenceFrequency.MONTHLY,
+      type: TransactionType.EXPENSE,
+      interval: 1,
+      startDate: '2024-01-01',
+      ...overrides,
+    };
+  }
+
+  it('should accept the classic single-amount payload', () => {
+    expect(
+      createRecurringTransactionSchema.safeParse(makeValid()).success,
+    ).toBe(true);
+  });
+
+  it('should accept a totalAmount + installments payload without amount', () => {
+    const result = createRecurringTransactionSchema.safeParse(
+      makeValid({ amount: undefined, totalAmount: 300000, installments: 3 }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it.each<[Record<string, unknown>, string]>([
+    [{ amount: undefined }, 'neither amount nor totalAmount/installments'],
+    [
+      { totalAmount: 300000, installments: undefined },
+      'totalAmount without installments',
+    ],
+    [
+      { amount: undefined, installments: 3 },
+      'installments without totalAmount',
+    ],
+    [
+      { totalAmount: 300000, installments: 3 },
+      'amount together with totalAmount + installments',
+    ],
+    [{ totalAmount: 0, installments: 3 }, 'zero totalAmount'],
+    [{ totalAmount: 300000, installments: 0 }, 'zero installments'],
+  ])('should reject %s', (overrides) => {
+    expect(
+      createRecurringTransactionSchema.safeParse(makeValid(overrides)).success,
+    ).toBe(false);
+  });
+});

--- a/src/modules/transaction/features/create-recurring-transaction/create-recurring-transaction.service.spec.ts
+++ b/src/modules/transaction/features/create-recurring-transaction/create-recurring-transaction.service.spec.ts
@@ -1,0 +1,251 @@
+import {
+  AccountType,
+  RecurrenceFrequency,
+  TransactionType,
+} from '@constants/enums';
+import { CheckingAccount } from '@modules/account/entities/CheckingAccount';
+import { AccountRepository } from '@modules/account/repositories/contracts/AccountRepository';
+import { CategoryRepository } from '@modules/category/repositories/contracts/CategoryRepository';
+import { Category } from '@modules/category/entities/Category';
+import { RecurringTransactionRepository } from '@modules/transaction/repositories/contracts/RecurringTransactionRepository';
+import { DateProvider } from '@providers/date/contracts/DateProvider';
+import { UnauthorizedError } from '@shared/errors/UnauthorizedError';
+import { CreateRecurringTransactionService } from './create-recurring-transaction.service';
+
+function makeAccount(workspaceId = 'ws-1', id = 'acc-1') {
+  const result = CheckingAccount.create(
+    {
+      workspaceId,
+      name: 'Account',
+      type: AccountType.CHECKING,
+      timezone: 'America/Sao_Paulo',
+      balance: 10000n,
+    },
+    id,
+  );
+  if (result.isLeft()) throw result.value;
+  return result.value;
+}
+
+function makeCategory(workspaceId: string | null = 'ws-1', id = 'cat-1') {
+  const result = Category.create(
+    {
+      workspaceId,
+      name: 'Moradia',
+      type: TransactionType.EXPENSE,
+      parentId: null,
+      isSystemCategory: false,
+    },
+    id,
+  );
+  if (result.isLeft()) throw result.value;
+  return result.value;
+}
+
+function makeRequest(overrides: Record<string, unknown> = {}) {
+  return {
+    sub: 'user-1',
+    workspaceId: 'ws-1',
+    accountId: 'acc-1',
+    title: 'Aluguel',
+    amount: 150000n,
+    frequency: RecurrenceFrequency.MONTHLY,
+    interval: 1,
+    type: TransactionType.EXPENSE,
+    startDate: '2099-02-01',
+    ...overrides,
+  };
+}
+
+describe('CreateRecurringTransactionService', () => {
+  let service: CreateRecurringTransactionService;
+  let recurringRepository: jest.Mocked<RecurringTransactionRepository>;
+  let accountRepository: jest.Mocked<AccountRepository>;
+  let categoryRepository: jest.Mocked<CategoryRepository>;
+  let dateProvider: jest.Mocked<DateProvider>;
+
+  beforeEach(() => {
+    recurringRepository = {
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      findById: jest.fn(),
+      findManyByWorkspaceId: jest.fn(),
+      findNeedingGenerationByWorkspaceId: jest.fn(),
+      listNeedingGeneration: jest.fn(),
+      createGeneratedTransactions: jest.fn(),
+    } as jest.Mocked<RecurringTransactionRepository>;
+
+    accountRepository = {
+      create: jest.fn(),
+      findByNameAndWorkspaceId: jest.fn(),
+      findById: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      findManyByWorkspaceId: jest.fn(),
+      findAllByWorkspaceId: jest.fn(),
+      countByWorkspaceId: jest.fn(),
+    } as jest.Mocked<AccountRepository>;
+
+    categoryRepository = {
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      findById: jest.fn(),
+      countByWorkspaceId: jest.fn(),
+      findUniqueByAttributes: jest.fn(),
+      findManyByWorkspaceId: jest.fn(),
+      countChildren: jest.fn(),
+      countTransactions: jest.fn(),
+      reassignChildren: jest.fn(),
+      findManyByIds: jest.fn(),
+    } as jest.Mocked<CategoryRepository>;
+
+    dateProvider = {
+      now: jest.fn().mockReturnValue(new Date('2024-01-01T00:00:00.000Z')),
+      add: jest.fn((date: Date, amount: number, unit: string) => {
+        const result = new Date(date);
+        if (unit === 'day') result.setUTCDate(result.getUTCDate() + amount);
+        if (unit === 'month') result.setUTCMonth(result.getUTCMonth() + amount);
+        if (unit === 'year')
+          result.setUTCFullYear(result.getUTCFullYear() + amount);
+        return result;
+      }),
+      format: jest.fn(),
+      toTimezone: jest.fn(),
+      calculateInvoiceCycle: jest.fn(),
+      addDaysInCurrentDate: jest.fn(),
+      parse: jest.fn(),
+      startOfDay: jest.fn((date) => new Date(date)),
+      endOfDay: jest.fn(),
+      startOfMonth: jest.fn(),
+      endOfMonth: jest.fn(),
+    } as unknown as jest.Mocked<DateProvider>;
+
+    service = new CreateRecurringTransactionService(
+      recurringRepository,
+      accountRepository,
+      categoryRepository,
+      dateProvider,
+    );
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  function arrangeSuccessMocks() {
+    accountRepository.findById.mockResolvedValue(makeAccount());
+    categoryRepository.findById.mockResolvedValue(null);
+    recurringRepository.create.mockImplementation(async (r) => r);
+  }
+
+  it('should return left(UnauthorizedError) when account is not found', async () => {
+    accountRepository.findById.mockResolvedValue(null);
+
+    const result = await service.execute(makeRequest());
+
+    expect(result.isLeft()).toBe(true);
+    expect(result.value).toBeInstanceOf(UnauthorizedError);
+  });
+
+  it('should return left(UnauthorizedError) when account belongs to another workspace', async () => {
+    accountRepository.findById.mockResolvedValue(makeAccount('ws-2'));
+
+    const result = await service.execute(makeRequest());
+
+    expect(result.isLeft()).toBe(true);
+    expect(result.value).toBeInstanceOf(UnauthorizedError);
+  });
+
+  it('should return left(UnauthorizedError) when destination account belongs to another workspace', async () => {
+    accountRepository.findById.mockImplementation(async (id) =>
+      id === 'acc-1' ? makeAccount() : makeAccount('ws-2', 'acc-2'),
+    );
+
+    const result = await service.execute(
+      makeRequest({
+        type: TransactionType.TRANSFER,
+        destinationAccountId: 'acc-2',
+      }),
+    );
+
+    expect(result.isLeft()).toBe(true);
+    expect(result.value).toBeInstanceOf(UnauthorizedError);
+  });
+
+  it('should return left(UnauthorizedError) when category belongs to another workspace', async () => {
+    accountRepository.findById.mockResolvedValue(makeAccount());
+    categoryRepository.findById.mockResolvedValue(makeCategory('ws-2'));
+
+    const result = await service.execute(makeRequest({ categoryId: 'cat-1' }));
+
+    expect(result.isLeft()).toBe(true);
+    expect(result.value).toBeInstanceOf(UnauthorizedError);
+  });
+
+  it('should accept a global category (no workspaceId)', async () => {
+    arrangeSuccessMocks();
+    categoryRepository.findById.mockResolvedValue(makeCategory(null));
+
+    const result = await service.execute(makeRequest({ categoryId: 'cat-1' }));
+
+    expect(result.isRight()).toBe(true);
+  });
+
+  it('should return left when startDate is today or in the past', async () => {
+    arrangeSuccessMocks();
+
+    const result = await service.execute(
+      makeRequest({ startDate: '2024-01-01' }),
+    );
+
+    expect(result.isLeft()).toBe(true);
+  });
+
+  it('should create the recurring transaction using the given amount', async () => {
+    arrangeSuccessMocks();
+
+    const result = await service.execute(makeRequest());
+
+    expect(result.isRight()).toBe(true);
+    expect(recurringRepository.create).toHaveBeenCalledTimes(1);
+    if (result.isRight()) expect(result.value.amount).toBe(150000n);
+  });
+
+  it('should split totalAmount across installments and compute the endDate', async () => {
+    arrangeSuccessMocks();
+
+    const result = await service.execute(
+      makeRequest({
+        amount: undefined,
+        totalAmount: 300000n,
+        installments: 3,
+        startDate: '2099-02-01',
+      }),
+    );
+
+    expect(result.isRight()).toBe(true);
+    if (result.isRight()) {
+      expect(result.value.amount).toBe(100000n);
+      expect(result.value.endDate).toEqual(new Date('2099-04-01'));
+    }
+  });
+
+  it('should compute the endDate respecting a custom interval', async () => {
+    arrangeSuccessMocks();
+
+    const result = await service.execute(
+      makeRequest({
+        amount: undefined,
+        totalAmount: 400000n,
+        installments: 4,
+        interval: 2,
+        startDate: '2099-02-01',
+      }),
+    );
+
+    expect(result.isRight()).toBe(true);
+    if (result.isRight()) {
+      expect(result.value.endDate).toEqual(new Date('2099-08-01'));
+    }
+  });
+});

--- a/src/modules/transaction/features/create-recurring-transaction/create-recurring-transaction.service.ts
+++ b/src/modules/transaction/features/create-recurring-transaction/create-recurring-transaction.service.ts
@@ -48,44 +48,17 @@ export class CreateRecurringTransactionService implements Service<
       return left(new UnauthorizedError());
     }
 
-    if (destinationAccountId) {
-      const destAccount =
-        await this.accountRepository.findById(destinationAccountId);
-      if (destAccount?.workspaceId !== workspaceId) {
-        return left(new UnauthorizedError());
-      }
-    }
+    const destinationError = await this.validateDestinationAccount(
+      destinationAccountId,
+      workspaceId,
+    );
+    if (destinationError) return left(destinationError);
 
-    if (categoryId) {
-      const category = await this.categoryRepository.findById(categoryId);
-      if (!category) return left(new RecurringTransactionNotFoundError());
-
-      const isGlobalCategory = !category.workspaceId;
-      const belongsToWorkspace = category.workspaceId === workspaceId;
-
-      if (!isGlobalCategory && !belongsToWorkspace) {
-        return left(
-          new UnauthorizedError('Você não tem acesso a esta categoria.'),
-        );
-      }
-    }
+    const categoryError = await this.validateCategory(categoryId, workspaceId);
+    if (categoryError) return left(categoryError);
 
     const accountTz = account.timezone;
-
     const start = this.dateProvider.startOfDay(startDate, accountTz);
-    const isTotalAmountMode = request.amount === undefined;
-    const end = isTotalAmountMode
-      ? this.calculateInstallmentEndDate(
-          start,
-          request.frequency as RecurrenceFrequency,
-          request.interval,
-          request.installments!,
-          accountTz,
-        )
-      : endDate
-        ? this.dateProvider.startOfDay(endDate, accountTz)
-        : null;
-
     const today = this.dateProvider.startOfDay(
       this.dateProvider.now(),
       accountTz,
@@ -95,12 +68,12 @@ export class CreateRecurringTransactionService implements Service<
       return left(new StartDateCannotBeTodayOrPastError());
     }
 
-    const amount = isTotalAmountMode
-      ? MoneyUtils.splitIntoInstallments(
-          request.totalAmount!,
-          request.installments!,
-        )
-      : request.amount!;
+    const { amount, end } = this.resolveAmountAndEndDate(
+      request,
+      start,
+      endDate,
+      accountTz,
+    );
 
     const recurringOrError = RecurringTransaction.create({
       workspaceId,
@@ -126,6 +99,77 @@ export class CreateRecurringTransactionService implements Service<
       recurringOrError.value,
     );
     return right(created);
+  }
+
+  private async validateDestinationAccount(
+    destinationAccountId: string | null | undefined,
+    workspaceId: string,
+  ): Promise<Error | null> {
+    if (!destinationAccountId) return null;
+
+    const destAccount =
+      await this.accountRepository.findById(destinationAccountId);
+    if (destAccount?.workspaceId !== workspaceId) {
+      return new UnauthorizedError();
+    }
+
+    return null;
+  }
+
+  private async validateCategory(
+    categoryId: string | null | undefined,
+    workspaceId: string,
+  ): Promise<Error | null> {
+    if (!categoryId) return null;
+
+    const category = await this.categoryRepository.findById(categoryId);
+    if (!category) return new RecurringTransactionNotFoundError();
+
+    const isGlobalCategory = !category.workspaceId;
+    const belongsToWorkspace = category.workspaceId === workspaceId;
+
+    if (!isGlobalCategory && !belongsToWorkspace) {
+      return new UnauthorizedError('Você não tem acesso a esta categoria.');
+    }
+
+    return null;
+  }
+
+  private resolveAmountAndEndDate(
+    request: Request,
+    start: Date,
+    endDate: string | null | undefined,
+    timezone: string,
+  ): { amount: bigint; end: Date | null } {
+    const isTotalAmountMode = request.amount === undefined;
+
+    if (isTotalAmountMode) {
+      const amount = MoneyUtils.splitIntoInstallments(
+        request.totalAmount!,
+        request.installments!,
+      );
+      const end = this.calculateInstallmentEndDate(
+        start,
+        request.frequency as RecurrenceFrequency,
+        request.interval,
+        request.installments!,
+        timezone,
+      );
+      return { amount, end };
+    }
+
+    return {
+      amount: request.amount!,
+      end: this.resolveManualEndDate(endDate, timezone),
+    };
+  }
+
+  private resolveManualEndDate(
+    endDate: string | null | undefined,
+    timezone: string,
+  ): Date | null {
+    if (!endDate) return null;
+    return this.dateProvider.startOfDay(endDate, timezone);
   }
 
   private calculateInstallmentEndDate(

--- a/src/modules/transaction/features/create-recurring-transaction/create-recurring-transaction.service.ts
+++ b/src/modules/transaction/features/create-recurring-transaction/create-recurring-transaction.service.ts
@@ -13,6 +13,7 @@ import { DateProvider } from '@providers/date/contracts/DateProvider';
 import { Service } from '@shared/core/contracts/Service';
 import { Either, left, right } from '@shared/core/errors/Either';
 import { UnauthorizedError } from '@shared/errors/UnauthorizedError';
+import { MoneyUtils } from '@utils/MoneyUtils';
 import { CreateRecurringTransactionRequest } from './create-recurring-transaction.dto';
 
 type Request = CreateRecurringTransactionRequest & TokenPayloadBase;
@@ -72,9 +73,18 @@ export class CreateRecurringTransactionService implements Service<
     const accountTz = account.timezone;
 
     const start = this.dateProvider.startOfDay(startDate, accountTz);
-    const end = endDate
-      ? this.dateProvider.startOfDay(endDate, accountTz)
-      : null;
+    const isTotalAmountMode = request.amount === undefined;
+    const end = isTotalAmountMode
+      ? this.calculateInstallmentEndDate(
+          start,
+          request.frequency as RecurrenceFrequency,
+          request.interval,
+          request.installments!,
+          accountTz,
+        )
+      : endDate
+        ? this.dateProvider.startOfDay(endDate, accountTz)
+        : null;
 
     const today = this.dateProvider.startOfDay(
       this.dateProvider.now(),
@@ -85,6 +95,13 @@ export class CreateRecurringTransactionService implements Service<
       return left(new StartDateCannotBeTodayOrPastError());
     }
 
+    const amount = isTotalAmountMode
+      ? MoneyUtils.splitIntoInstallments(
+          request.totalAmount!,
+          request.installments!,
+        )
+      : request.amount!;
+
     const recurringOrError = RecurringTransaction.create({
       workspaceId,
       accountId,
@@ -92,7 +109,7 @@ export class CreateRecurringTransactionService implements Service<
       title: request.title,
       description: request.description ?? null,
       categoryId: categoryId ?? null,
-      amount: request.amount,
+      amount,
       frequency: request.frequency as RecurrenceFrequency,
       interval: request.interval,
       type: request.type,
@@ -109,5 +126,41 @@ export class CreateRecurringTransactionService implements Service<
       recurringOrError.value,
     );
     return right(created);
+  }
+
+  private calculateInstallmentEndDate(
+    start: Date,
+    frequency: RecurrenceFrequency,
+    interval: number,
+    installments: number,
+    timezone: string,
+  ): Date {
+    const remainingOccurrences = installments - 1;
+
+    switch (frequency) {
+      case RecurrenceFrequency.WEEKLY:
+        return this.dateProvider.add(
+          start,
+          interval * 7 * remainingOccurrences,
+          'day',
+          timezone,
+        );
+      case RecurrenceFrequency.MONTHLY:
+        return this.dateProvider.add(
+          start,
+          interval * remainingOccurrences,
+          'month',
+          timezone,
+        );
+      case RecurrenceFrequency.YEARLY:
+        return this.dateProvider.add(
+          start,
+          interval * remainingOccurrences,
+          'year',
+          timezone,
+        );
+      default:
+        throw new Error(`Unknown frequency: ${frequency}`);
+    }
   }
 }

--- a/src/utils/MoneyUtils.spec.ts
+++ b/src/utils/MoneyUtils.spec.ts
@@ -1,0 +1,31 @@
+import { MoneyUtils } from './MoneyUtils';
+
+describe('MoneyUtils.splitIntoInstallments', () => {
+  it('should split an exact amount evenly across installments', () => {
+    expect(MoneyUtils.splitIntoInstallments(10000n, 4)).toBe(2500n);
+  });
+
+  it('should floor the per-installment value when the division has a remainder', () => {
+    expect(MoneyUtils.splitIntoInstallments(10000n, 3)).toBe(3333n);
+  });
+
+  it('should return the full amount when installments is 1', () => {
+    expect(MoneyUtils.splitIntoInstallments(10000n, 1)).toBe(10000n);
+  });
+
+  it('should handle large amounts', () => {
+    expect(MoneyUtils.splitIntoInstallments(100000000000n, 12)).toBe(
+      8333333333n,
+    );
+  });
+
+  it('should throw when installments is zero or negative', () => {
+    expect(() => MoneyUtils.splitIntoInstallments(10000n, 0)).toThrow();
+    expect(() => MoneyUtils.splitIntoInstallments(10000n, -1)).toThrow();
+  });
+
+  it('should throw when totalAmountCents is zero or negative', () => {
+    expect(() => MoneyUtils.splitIntoInstallments(0n, 3)).toThrow();
+    expect(() => MoneyUtils.splitIntoInstallments(-100n, 3)).toThrow();
+  });
+});

--- a/src/utils/MoneyUtils.ts
+++ b/src/utils/MoneyUtils.ts
@@ -133,4 +133,22 @@ export class MoneyUtils {
 
     return enriched;
   }
+
+  /**
+   * Divide um valor total em parcelas de valor igual, arredondando para baixo.
+   * Divisões não exatas resultam em imprecisão de centavos (aceitável).
+   */
+  static splitIntoInstallments(
+    totalAmountCents: bigint,
+    installments: number,
+  ): bigint {
+    if (installments <= 0) {
+      throw new Error('O número de parcelas deve ser maior que zero');
+    }
+    if (totalAmountCents <= 0n) {
+      throw new Error('O valor total deve ser maior que zero');
+    }
+
+    return totalAmountCents / BigInt(installments);
+  }
 }


### PR DESCRIPTION
This wraps up the "valor total → parcelas" idea for the credit-card pivot: instead of the user calculating each installment's value by hand, they can now send `totalAmount` + `installments` when creating a recurring transaction and let the backend do the math.

Added `MoneyUtils.splitIntoInstallments(totalAmountCents, installments)` — a small pure function, floor division, no remainder redistribution (accepted imprecision on non-exact divisions, as we discussed).

On the DTO side, `amount` is now optional and there's a new `totalAmount`/`installments` pair, with a few `refine()` checks making sure exactly one mode is used — you either send the classic `amount`, or `totalAmount` + `installments` together, never a mix.

On the handler side, when total-amount mode is used it computes the per-installment amount and also auto-calculates `endDate` from `startDate + interval * (installments - 1)`. That last part matters: it's what makes the auto-deactivate logic from the previous PR actually kick in right after the last installment is generated, instead of leaving the recurrence dangling with no end date.

Also worth flagging: neither `create-recurring-transaction.service.ts` nor `MoneyUtils` had any test coverage before this, so I wrote the baseline specs first before touching anything, same approach as last time.

Smoke-tested against a real running instance (docker-compose + npm run dev): created a recurring with totalAmount 3000 / installments 3 and got amount 100 / endDate two months out, exactly as expected. Also confirmed the API rejects a payload that mixes `amount` with `totalAmount`/`installments`.

53/53 suites, 413/413 tests green, tsc and lint clean.