### PR TITLE
fix(account): stop swallowing invoice/balance validation errors as generic 500s

### DIFF
--- a/src/modules/account/entities/BaseAccount.ts
+++ b/src/modules/account/entities/BaseAccount.ts
@@ -1,3 +1,7 @@
+import {
+  InsufficientBalanceError,
+  ValidationAccountError,
+} from '@modules/account/errors';
 import { Either, left, right } from '@shared/core/errors/Either';
 import { AggregateRoot } from '@shared/core/Entities/AggregateRoot';
 
@@ -37,7 +41,8 @@ export abstract class BaseAccount<
    * Sobrescreva quando a conta precisar de uma regra diferente.
    */
   public credit(amount: bigint): Either<Error, void> {
-    if (amount <= 0n) return left(new Error('Valor deve ser positivo.'));
+    if (amount <= 0n)
+      return left(new ValidationAccountError('Valor deve ser positivo.'));
     this.props.balance += amount;
     return right(undefined);
   }
@@ -48,10 +53,13 @@ export abstract class BaseAccount<
    * permitir saldo negativo (ex.: conta corrente) ou tiver outra regra.
    */
   public debit(amount: bigint): Either<Error, void> {
-    if (amount <= 0n) return left(new Error('Valor deve ser positivo.'));
+    if (amount <= 0n)
+      return left(new ValidationAccountError('Valor deve ser positivo.'));
     if (this.props.balance - amount < 0n) {
       return left(
-        new Error('Saldo insuficiente na carteira. Operação bloqueada.'),
+        new InsufficientBalanceError(
+          'Saldo insuficiente na carteira. Operação bloqueada.',
+        ),
       );
     }
     this.props.balance -= amount;

--- a/src/modules/account/entities/CashAccounts.spec.ts
+++ b/src/modules/account/entities/CashAccounts.spec.ts
@@ -1,4 +1,8 @@
 import { AccountType } from '@constants/enums';
+import {
+  InsufficientBalanceError,
+  ValidationAccountError,
+} from '@modules/account/errors';
 import { CashAccount } from './CashAccounts';
 
 describe('CashAccount entity', () => {
@@ -34,6 +38,8 @@ describe('CashAccount entity', () => {
     it('should reject negative initial balance', () => {
       const result = CashAccount.create(makeProps({ balance: -1n }));
       expect(result.isLeft()).toBe(true);
+      if (result.isLeft())
+        expect(result.value).toBeInstanceOf(ValidationAccountError);
     });
 
     it('should return type CASH', () => {
@@ -54,7 +60,10 @@ describe('CashAccount entity', () => {
     });
 
     it('should reject zero amount', () => {
-      expect(makeAccount().credit(0n).isLeft()).toBe(true);
+      const result = makeAccount().credit(0n);
+      expect(result.isLeft()).toBe(true);
+      if (result.isLeft())
+        expect(result.value).toBeInstanceOf(ValidationAccountError);
     });
 
     it('should reject negative amount', () => {
@@ -79,7 +88,10 @@ describe('CashAccount entity', () => {
 
     it('should reject debit exceeding balance', () => {
       const account = makeAccount(100n);
-      expect(account.debit(200n).isLeft()).toBe(true);
+      const result = account.debit(200n);
+      expect(result.isLeft()).toBe(true);
+      if (result.isLeft())
+        expect(result.value).toBeInstanceOf(InsufficientBalanceError);
     });
   });
 

--- a/src/modules/account/entities/CashAccounts.ts
+++ b/src/modules/account/entities/CashAccounts.ts
@@ -1,4 +1,5 @@
 import { AccountType } from '@constants/enums';
+import { ValidationAccountError } from '@modules/account/errors';
 import { Either, left, right } from '@shared/core/errors/Either';
 import { BaseAccount, BaseAccountProps } from './BaseAccount';
 
@@ -17,7 +18,11 @@ export class CashAccount extends BaseAccount<CashAccountProps> {
   ): Either<Error, CashAccount> {
     const initialBalance = props.balance ?? 0n;
     if (initialBalance < 0n)
-      return left(new Error('Dinheiro em espécie não pode ser negativo.'));
+      return left(
+        new ValidationAccountError(
+          'Dinheiro em espécie não pode ser negativo.',
+        ),
+      );
 
     return right(new CashAccount({ ...props, balance: initialBalance }, id));
   }

--- a/src/modules/account/entities/CheckingAccount.spec.ts
+++ b/src/modules/account/entities/CheckingAccount.spec.ts
@@ -1,4 +1,5 @@
 import { AccountType } from '@constants/enums';
+import { ValidationAccountError } from '@modules/account/errors';
 import { CheckingAccount } from './CheckingAccount';
 
 function makeProps(
@@ -36,6 +37,8 @@ describe('CheckingAccount entity', () => {
     it('should reject name with less than 2 characters', () => {
       const result = CheckingAccount.create(makeProps({ name: 'A' }));
       expect(result.isLeft()).toBe(true);
+      if (result.isLeft())
+        expect(result.value).toBeInstanceOf(ValidationAccountError);
     });
   });
 
@@ -48,7 +51,10 @@ describe('CheckingAccount entity', () => {
 
     it('should reject zero amount', () => {
       const account = makeAccount();
-      expect(account.credit(0n).isLeft()).toBe(true);
+      const result = account.credit(0n);
+      expect(result.isLeft()).toBe(true);
+      if (result.isLeft())
+        expect(result.value).toBeInstanceOf(ValidationAccountError);
     });
 
     it('should reject negative amount', () => {

--- a/src/modules/account/entities/CheckingAccount.ts
+++ b/src/modules/account/entities/CheckingAccount.ts
@@ -1,4 +1,5 @@
 import { AccountType } from '@constants/enums';
+import { ValidationAccountError } from '@modules/account/errors';
 import { Either, left, right } from '@shared/core/errors/Either';
 import { BaseAccount, BaseAccountProps } from './BaseAccount';
 
@@ -16,7 +17,8 @@ export class CheckingAccount extends BaseAccount<CheckingAccountProps> {
     props: Omit<CheckingAccountProps, 'balance'> & { balance?: bigint },
     id?: string,
   ): Either<Error, CheckingAccount> {
-    if (props.name.length < 2) return left(new Error('Nome muito curto.'));
+    if (props.name.length < 2)
+      return left(new ValidationAccountError('Nome muito curto.'));
 
     return right(
       new CheckingAccount(
@@ -45,7 +47,8 @@ export class CheckingAccount extends BaseAccount<CheckingAccountProps> {
   }
 
   public debit(amount: bigint): Either<Error, void> {
-    if (amount <= 0n) return left(new Error('Valor deve ser positivo.'));
+    if (amount <= 0n)
+      return left(new ValidationAccountError('Valor deve ser positivo.'));
     this.props.balance -= amount;
     return right(undefined);
   }

--- a/src/modules/account/entities/CreditCardAccount.spec.ts
+++ b/src/modules/account/entities/CreditCardAccount.spec.ts
@@ -1,3 +1,8 @@
+import {
+  CreditLimitExceededError,
+  PaymentExceedsInvoiceBalanceError,
+  ValidationAccountError,
+} from '@modules/account/errors';
 import { CreditCard } from './CreditCardAccount';
 
 describe('CreditCard entity', () => {
@@ -47,7 +52,10 @@ describe('CreditCard entity', () => {
       [{ dueDay: 0 }, 'dueDay 0'],
       [{ dueDay: 32 }, 'dueDay 32'],
     ])('should reject %s', (props) => {
-      expect(CreditCard.create(makeProps(props)).isLeft()).toBe(true);
+      const result = CreditCard.create(makeProps(props));
+      expect(result.isLeft()).toBe(true);
+      if (result.isLeft())
+        expect(result.value).toBeInstanceOf(ValidationAccountError);
     });
 
     it('should default balance to 0 when not provided', () => {
@@ -64,12 +72,18 @@ describe('CreditCard entity', () => {
     });
 
     it('should reject zero amount', () => {
-      expect(makeCard().registerCharge(0n).isLeft()).toBe(true);
+      const result = makeCard().registerCharge(0n);
+      expect(result.isLeft()).toBe(true);
+      if (result.isLeft())
+        expect(result.value).toBeInstanceOf(ValidationAccountError);
     });
 
     it('should reject charge exceeding available limit', () => {
       const card = makeCard({ creditLimit: 1000n });
-      expect(card.registerCharge(1500n).isLeft()).toBe(true);
+      const result = card.registerCharge(1500n);
+      expect(result.isLeft()).toBe(true);
+      if (result.isLeft())
+        expect(result.value).toBeInstanceOf(CreditLimitExceededError);
     });
 
     it('should allow any charge when creditLimit is null (unlimited)', () => {
@@ -87,13 +101,19 @@ describe('CreditCard entity', () => {
     });
 
     it('should reject zero amount', () => {
-      expect(makeCard().payInvoice(0n).isLeft()).toBe(true);
+      const result = makeCard().payInvoice(0n);
+      expect(result.isLeft()).toBe(true);
+      if (result.isLeft())
+        expect(result.value).toBeInstanceOf(ValidationAccountError);
     });
 
     it('should reject payment exceeding current balance', () => {
       const card = makeCard();
       card.registerCharge(200n);
-      expect(card.payInvoice(500n).isLeft()).toBe(true);
+      const result = card.payInvoice(500n);
+      expect(result.isLeft()).toBe(true);
+      if (result.isLeft())
+        expect(result.value).toBeInstanceOf(PaymentExceedsInvoiceBalanceError);
     });
   });
 
@@ -106,7 +126,10 @@ describe('CreditCard entity', () => {
 
     it('should reject expense exceeding available limit', () => {
       const card = makeCard({ creditLimit: 1000n });
-      expect(card.applyExpenseEffect(1500n).isLeft()).toBe(true);
+      const result = card.applyExpenseEffect(1500n);
+      expect(result.isLeft()).toBe(true);
+      if (result.isLeft())
+        expect(result.value).toBeInstanceOf(CreditLimitExceededError);
     });
   });
 
@@ -121,7 +144,10 @@ describe('CreditCard entity', () => {
     it('should reject income exceeding current balance', () => {
       const card = makeCard();
       card.registerCharge(200n);
-      expect(card.applyIncomeEffect(500n).isLeft()).toBe(true);
+      const result = card.applyIncomeEffect(500n);
+      expect(result.isLeft()).toBe(true);
+      if (result.isLeft())
+        expect(result.value).toBeInstanceOf(PaymentExceedsInvoiceBalanceError);
     });
   });
 
@@ -133,7 +159,11 @@ describe('CreditCard entity', () => {
     });
 
     it('should reject zero or negative limit', () => {
-      expect(makeCard().adjustLimit(0n).isLeft()).toBe(true);
+      const zeroResult = makeCard().adjustLimit(0n);
+      expect(zeroResult.isLeft()).toBe(true);
+      if (zeroResult.isLeft())
+        expect(zeroResult.value).toBeInstanceOf(ValidationAccountError);
+
       expect(makeCard().adjustLimit(-500n).isLeft()).toBe(true);
     });
   });

--- a/src/modules/account/entities/CreditCardAccount.ts
+++ b/src/modules/account/entities/CreditCardAccount.ts
@@ -1,4 +1,9 @@
 import { AccountType } from '@constants/enums';
+import {
+  CreditLimitExceededError,
+  PaymentExceedsInvoiceBalanceError,
+  ValidationAccountError,
+} from '@modules/account/errors';
 import { Either, left, right } from '@shared/core/errors/Either';
 import { BaseAccount, BaseAccountProps } from './BaseAccount';
 
@@ -23,17 +28,21 @@ export class CreditCard extends BaseAccount<CreditCardProps> {
       props.creditLimit !== undefined &&
       props.creditLimit <= 0n
     ) {
-      return left(new Error('O limite de crédito deve ser superior a zero.'));
+      return left(
+        new ValidationAccountError(
+          'O limite de crédito deve ser superior a zero.',
+        ),
+      );
     }
     if (
       props.closingDay !== null &&
       props.closingDay !== undefined &&
       (props.closingDay < 1 || props.closingDay > 31)
     ) {
-      return left(new Error('Dia de fechamento inválido.'));
+      return left(new ValidationAccountError('Dia de fechamento inválido.'));
     }
     if (props.dueDay < 1 || props.dueDay > 31) {
-      return left(new Error('Dia de vencimento inválido.'));
+      return left(new ValidationAccountError('Dia de vencimento inválido.'));
     }
 
     return right(
@@ -80,10 +89,14 @@ export class CreditCard extends BaseAccount<CreditCardProps> {
 
   public registerCharge(amount: bigint): Either<Error, void> {
     if (amount <= 0n) {
-      return left(new Error('O valor da cobrança deve ser maior que zero.'));
+      return left(
+        new ValidationAccountError(
+          'O valor da cobrança deve ser maior que zero.',
+        ),
+      );
     }
     if (this.props.creditLimit !== null && amount > this.availableLimit!) {
-      return left(new Error('Limite de crédito insuficiente.'));
+      return left(new CreditLimitExceededError(this.availableLimit!, amount));
     }
 
     this.props.balance += amount;
@@ -92,13 +105,15 @@ export class CreditCard extends BaseAccount<CreditCardProps> {
 
   public payInvoice(amount: bigint): Either<Error, void> {
     if (amount <= 0n) {
-      return left(new Error('O valor do pagamento deve ser maior que zero.'));
+      return left(
+        new ValidationAccountError(
+          'O valor do pagamento deve ser maior que zero.',
+        ),
+      );
     }
 
     if (this.props.balance - amount < 0n) {
-      return left(
-        new Error('O pagamento não pode exceder o valor da fatura atual.'),
-      );
+      return left(new PaymentExceedsInvoiceBalanceError());
     }
 
     this.props.balance -= amount;
@@ -118,10 +133,10 @@ export class CreditCard extends BaseAccount<CreditCardProps> {
     dueDay: number,
   ): Either<Error, void> {
     if (closingDay !== null && (closingDay < 1 || closingDay > 31)) {
-      return left(new Error('Dia de fechamento inválido.'));
+      return left(new ValidationAccountError('Dia de fechamento inválido.'));
     }
     if (dueDay < 1 || dueDay > 31) {
-      return left(new Error('Dia de vencimento inválido.'));
+      return left(new ValidationAccountError('Dia de vencimento inválido.'));
     }
     this.props.closingDay = closingDay;
     this.props.dueDay = dueDay;
@@ -130,7 +145,11 @@ export class CreditCard extends BaseAccount<CreditCardProps> {
 
   public adjustLimit(newLimit: bigint | null): Either<Error, void> {
     if (newLimit !== null && newLimit <= 0n) {
-      return left(new Error('O limite de crédito deve ser superior a zero.'));
+      return left(
+        new ValidationAccountError(
+          'O limite de crédito deve ser superior a zero.',
+        ),
+      );
     }
     this.props.creditLimit = newLimit;
     return right(undefined);

--- a/src/modules/account/entities/InvestmentAccount.spec.ts
+++ b/src/modules/account/entities/InvestmentAccount.spec.ts
@@ -1,4 +1,8 @@
 import { AccountType } from '@constants/enums';
+import {
+  InsufficientBalanceError,
+  ValidationAccountError,
+} from '@modules/account/errors';
 import { InvestmentAccount } from './InvestmentAccount';
 
 describe('InvestmentAccount entity', () => {
@@ -33,9 +37,10 @@ describe('InvestmentAccount entity', () => {
     });
 
     it('should reject negative initial balance', () => {
-      expect(
-        InvestmentAccount.create(makeProps({ balance: -1n })).isLeft(),
-      ).toBe(true);
+      const result = InvestmentAccount.create(makeProps({ balance: -1n }));
+      expect(result.isLeft()).toBe(true);
+      if (result.isLeft())
+        expect(result.value).toBeInstanceOf(ValidationAccountError);
     });
 
     it('should return type INVESTMENT', () => {
@@ -68,7 +73,10 @@ describe('InvestmentAccount entity', () => {
     });
 
     it('should reject debit exceeding balance', () => {
-      expect(makeAccount(100n).debit(200n).isLeft()).toBe(true);
+      const result = makeAccount(100n).debit(200n);
+      expect(result.isLeft()).toBe(true);
+      if (result.isLeft())
+        expect(result.value).toBeInstanceOf(InsufficientBalanceError);
     });
   });
 

--- a/src/modules/account/entities/InvestmentAccount.ts
+++ b/src/modules/account/entities/InvestmentAccount.ts
@@ -1,4 +1,5 @@
 import { AccountType } from '@constants/enums';
+import { ValidationAccountError } from '@modules/account/errors';
 import { Either, left, right } from '@shared/core/errors/Either';
 import { BaseAccount, BaseAccountProps } from './BaseAccount';
 
@@ -17,7 +18,9 @@ export class InvestmentAccount extends BaseAccount<InvestmentAccountProps> {
   ): Either<Error, InvestmentAccount> {
     const initialBalance = props.balance ?? 0n;
     if (initialBalance < 0n)
-      return left(new Error('Saldo inicial não pode ser negativo.'));
+      return left(
+        new ValidationAccountError('Saldo inicial não pode ser negativo.'),
+      );
 
     return right(
       new InvestmentAccount({ ...props, balance: initialBalance }, id),

--- a/src/modules/account/errors/index.ts
+++ b/src/modules/account/errors/index.ts
@@ -25,7 +25,7 @@ export class ConflictAccountError extends ConflictDomainError {
 }
 
 export class CreditLimitExceededError extends BusinessRuleDomainError {
-  constructor(available: number, requested: number) {
+  constructor(available: bigint, requested: bigint) {
     super(
       `Limite insuficiente. Disponível: ${available}, Requisitado: ${requested}`,
     );
@@ -41,5 +41,17 @@ export class InvalidAccountError extends BusinessRuleDomainError {
 export class ValidationAccountError extends BusinessRuleDomainError {
   constructor(reason: string) {
     super(`Erro de validação na conta: ${reason}`);
+  }
+}
+
+export class InsufficientBalanceError extends BusinessRuleDomainError {
+  constructor(reason = 'Saldo insuficiente para essa operação.') {
+    super(reason);
+  }
+}
+
+export class PaymentExceedsInvoiceBalanceError extends BusinessRuleDomainError {
+  constructor() {
+    super('O pagamento não pode exceder o valor da fatura atual.');
   }
 }

--- a/src/modules/account/features/get-credit-card-invoice/get-credit-card-invoice.handler.spec.ts
+++ b/src/modules/account/features/get-credit-card-invoice/get-credit-card-invoice.handler.spec.ts
@@ -1,4 +1,4 @@
-import { AccountType } from '@constants/enums';
+import { AccountType, TransactionStatus } from '@constants/enums';
 import { CheckingAccount } from '@modules/account/entities/CheckingAccount';
 import { CreditCard } from '@modules/account/entities/CreditCardAccount';
 import {
@@ -6,6 +6,7 @@ import {
   AccountTypeError,
 } from '@modules/account/errors';
 import { AccountRepository } from '@modules/account/repositories/contracts/AccountRepository';
+import { Transaction } from '@modules/transaction/entities/Transaction';
 import { TransactionRepository } from '@modules/transaction/repositories/contracts/TransactionRepository';
 import {
   DateProvider,
@@ -56,6 +57,20 @@ function makeCheckingAccount(): CheckingAccount {
     },
     'acc-2',
   );
+  if (r.isLeft()) throw r.value;
+  return r.value;
+}
+
+function makeCompletedCharge(amount: bigint): Transaction {
+  const r = Transaction.create({
+    workspaceId: 'ws-1',
+    accountId: 'acc-1',
+    title: 'Compra no cartão',
+    amount,
+    date: new Date('2024-01-20'),
+    type: 'EXPENSE',
+    status: TransactionStatus.COMPLETED,
+  });
   if (r.isLeft()) throw r.value;
   return r.value;
 }
@@ -158,6 +173,30 @@ describe('GetCreditCardInvoiceService', () => {
     expect(dateProvider.calculateInvoiceCycle).toHaveBeenCalledWith(
       expect.objectContaining({ closingDay: 5, dueDay: 15 }),
     );
+  });
+
+  it('should cap totalAmount at the card current balance when a partial payment was already made this cycle', async () => {
+    // Bug reportado: duas cobranças de 5000 cada (10000 no total) nesse
+    // ciclo, mas o usuário já pagou parcialmente 3000 (a transação de
+    // pagamento não aparece na lista, pois pertence à conta de origem, não
+    // ao cartão). O saldo real da fatura é 7000 — é isso que o usuário pode
+    // efetivamente pagar, e é isso que payInvoice() valida.
+    const card = makeCreditCard();
+    card.registerCharge(10000n);
+    card.payInvoice(3000n);
+    expect(card.balance).toBe(7000n);
+
+    accountRepository.findById.mockResolvedValue(card);
+    transactionRepository.findByAccountAndDateRange.mockResolvedValue([
+      makeCompletedCharge(5000n),
+      makeCompletedCharge(5000n),
+    ]);
+
+    const result = await service.execute(makeRequest());
+    expect(result.isRight()).toBe(true);
+    if (result.isRight()) {
+      expect(result.value.totalAmount).toBe(7000);
+    }
   });
 
   it('should use closingDay=1 as fallback when account has no closingDay', async () => {

--- a/src/modules/account/features/get-credit-card-invoice/get-credit-card-invoice.handler.ts
+++ b/src/modules/account/features/get-credit-card-invoice/get-credit-card-invoice.handler.ts
@@ -73,9 +73,18 @@ export class GetCreditCardInvoiceService implements Service<
         periodEnd,
       );
 
-    const totalAmount = transactions
+    const chargesTotal = transactions
       .filter((t) => t.status === TransactionStatus.COMPLETED)
       .reduce((sum, t) => sum + Number(t.amount), 0);
+
+    // O total de cobranças do período não desconta pagamentos já feitos nesse
+    // ciclo (a query acima só traz transações do próprio cartão, não a
+    // transferência de pagamento, que pertence à conta de origem). Por isso o
+    // valor exibido/pagável nunca pode ultrapassar o saldo real da fatura
+    // (account.balance), que é o que CreditCard.payInvoice() de fato valida —
+    // caso contrário o usuário via um "Total da Fatura" inflado e a tentativa
+    // de pagar o valor cheio era rejeitada por "exceder" a fatura.
+    const totalAmount = Math.min(chargesTotal, Number(account.balance));
 
     const pendingAmount = transactions
       .filter((t) => t.status === TransactionStatus.PENDING)


### PR DESCRIPTION
## O que tava rolando

Issue #41: usuário clicava em pagar a fatura, valor exibido tava certo, e mesmo assim o pagamento falhava com um "Erro ao pagar fatura. Tente novamente." genérico.

Cavei o motivo real e são dois problemas empilhados:

**1. Erro de negócio virando 500 opaco**

`CreditCard.payInvoice()` / `registerCharge()` (e o `debit`/`credit` equivalente em `CashAccount`, `CheckingAccount`, `InvestmentAccount`) retornavam `left(new Error('...'))` — um `Error` puro, não uma subclasse de `BusinessRuleDomainError`. O `ErrorPresenter` só reconhece erros de domínio tipados pra mapear o status HTTP certo; um `Error` genérico cai no fallback e vira 500 "Erro interno do servidor", jogando fora a mensagem real. No FE isso virava `ServerError`, que a action `payInvoice()` não trata — daí o texto genérico hardcoded.

**2. O gatilho real do erro**

`GetCreditCardInvoiceService` calculava o `totalAmount` da fatura somando só as cobranças (`EXPENSE`) do ciclo — mas a transação de pagamento pertence à conta de origem, não ao cartão, então nunca entrava nessa soma. Resultado: se o usuário já tinha feito um pagamento parcial e voltava pra quitar o resto, a tela mostrava o total original da fatura (parecendo certo), só que pagar aquele valor estourava o saldo real do cartão e era rejeitado. Capei o `totalAmount` no saldo real da conta (`account.balance`), que é exatamente o que `payInvoice()` valida — os dois nunca mais divergem.

## O que mudou

- Novos erros de domínio em `src/modules/account/errors/index.ts` (`PaymentExceedsInvoiceBalanceError`, `InsufficientBalanceError`, ajuste no `CreditLimitExceededError`) e reaproveitamento do `ValidationAccountError` já existente pras validações simples.
- `CreditCardAccount.ts`, `CashAccounts.ts`, `CheckingAccount.ts`, `InvestmentAccount.ts`, `BaseAccount.ts`: trocado todo `new Error(...)` por erro de domínio tipado (menos o `updateName`, que lança `throw` direto e é um mecanismo de erro diferente — fora de escopo aqui).
- `GetCreditCardInvoiceService`: `totalAmount` agora é `Math.min(cobranças do ciclo, account.balance)`.
- Specs atualizados/adicionados pra validar `instanceof` do erro certo em cada caso, e um teste novo reproduzindo o cenário do pagamento parcial (`get-credit-card-invoice.handler.spec.ts`).

Nenhuma mudança de schema, rota ou contrato de API. Frontend não precisa de nenhum ajuste: assim que o erro virar 422 com mensagem certa, o `payInvoice()` action já trata `ValidationError` e mostra a mensagem no toast.

## Testes

`npm run test` — 54 suites / 441 testes, tudo verde. `npm run lint` e `npm run build` limpos nos arquivos tocados.

Closes #41